### PR TITLE
Hide People Nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@councildataproject/cdp-frontend",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "16.x",
     "npm": "8.x"
   },
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Front-end tooling library for React components for CDP instance deployments. Fork of @councildataproject/cdp-frontend.",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -105,7 +105,7 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
                         {strings.events}
                       </Link>
                     </li>
-                    <li className="mzp-c-menu-category">
+                    {/* <li className="mzp-c-menu-category">
                       <Link
                         to="/people"
                         className="mzp-c-menu-title"
@@ -113,7 +113,7 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
                       >
                         {strings.people}
                       </Link>
-                    </li>
+                    </li> */}
                   </ul>
                 </nav>
               </div>


### PR DESCRIPTION
We don't (yet) ingest people entities in the MT Legislature scraper, so we don't need to display "People" prominent in the UI.